### PR TITLE
added option -n for non-interactive mode

### DIFF
--- a/pngview/README.md
+++ b/pngview/README.md
@@ -10,4 +10,5 @@ Utility to display a PNG image on the Raspberry Pi screen using the Dispmanx win
     -l - DispmanX layer number
     -x - offset (pixels from the left)
     -y - offset (pixels from the top)
+    -n - non-interactive mode
 

--- a/pngview/pngview.c
+++ b/pngview/pngview.c
@@ -83,6 +83,7 @@ void usage(void)
     fprintf(stderr, "    -l - DispmanX layer number\n");
     fprintf(stderr, "    -x - offset (pixels from the left)\n");
     fprintf(stderr, "    -y - offset (pixels from the top)\n");
+    fprintf(stderr, "    -n - non-interactive mode\n");
 
     exit(EXIT_FAILURE);
 }
@@ -98,6 +99,7 @@ int main(int argc, char *argv[])
     int32_t yOffset = 0;
     bool xOffsetSet = false;
     bool yOffsetSet = false;
+    bool interactive = true;
 
     program = basename(argv[0]);
 
@@ -105,7 +107,7 @@ int main(int argc, char *argv[])
 
     int opt = 0;
 
-    while ((opt = getopt(argc, argv, "b:d:l:x:y:")) != -1)
+    while ((opt = getopt(argc, argv, "b:d:l:x:y:n")) != -1)
     {
         switch(opt)
         {
@@ -135,6 +137,10 @@ int main(int argc, char *argv[])
             yOffset = strtol(optarg, NULL, 10);
             yOffsetSet = true;
             break;
+        
+        case 'n':
+			interactive = false;
+			break;
 
         default:
 
@@ -234,7 +240,7 @@ int main(int argc, char *argv[])
     while (run)
     {
         int c = 0;
-        if (keyPressed(&c))
+        if (interactive && keyPressed(&c))
         {
             c = tolower(c);
 


### PR DESCRIPTION
Hi Andrew,

I'm using the pngview program to show a small machine-specific overlay, so when I later record the display for tutorials, it's easy to see which machine I'm working with at that time. pngview thus simply runs in the background.

I've added a new command line option "-n" for non-interactive mode: if specified, no keypresses are read any longer to avoid spurious behavior.

Thanks for these useful tools!