### PR TITLE
Read image from stdin when '-' is given as the image path parameter

### DIFF
--- a/common/loadpng.c
+++ b/common/loadpng.c
@@ -43,18 +43,28 @@
 bool
 loadPng(
     IMAGE_T* image,
-    const char *file)
+    const char *path)
 {
-    FILE* fpin = fopen(file, "rb");
+    FILE* file = fopen(path, "rb");
 
-    if (fpin == NULL)
+    if (file == NULL)
     {
         fprintf(stderr, "loadpng: can't open file for reading\n");
         return false;
     }
 
-    //---------------------------------------------------------------------
+    bool result = loadPngFile(image, file);
 
+    fclose(file);
+
+    return result;
+}
+
+bool
+loadPngFile(
+    IMAGE_T* image,
+    FILE *file)
+{
     png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,
                                                  NULL,
                                                  NULL,
@@ -62,7 +72,6 @@ loadPng(
 
     if (png_ptr == NULL)
     {
-        fclose(fpin);
         return false;
     }
 
@@ -71,20 +80,18 @@ loadPng(
     if (info_ptr == NULL)
     {
         png_destroy_read_struct(&png_ptr, 0, 0);
-        fclose(fpin);
         return false;
     }
 
     if (setjmp(png_jmpbuf(png_ptr)))
     {
         png_destroy_read_struct(&png_ptr, &info_ptr, 0);
-        fclose(fpin);
         return false;
     }
 
     //---------------------------------------------------------------------
 
-    png_init_io(png_ptr, fpin);
+    png_init_io(png_ptr, file);
 
     png_read_info(png_ptr, info_ptr);
 
@@ -166,8 +173,6 @@ loadPng(
     png_read_image(png_ptr, row_pointers);
 
     //---------------------------------------------------------------------
-
-    fclose(fpin);
 
     free(row_pointers);
 

--- a/common/loadpng.h
+++ b/common/loadpng.h
@@ -29,12 +29,14 @@
 #define LOADPNG_H
 
 #include <stdbool.h>
+#include <stdio.h>
 
 #include "image.h"
 
 //-------------------------------------------------------------------------
 
-bool loadPng(IMAGE_T *image, const char *file);
+bool loadPng(IMAGE_T *image, const char *path);
+bool loadPngFile(IMAGE_T* image, FILE *file);
 
 //-------------------------------------------------------------------------
 

--- a/pngview/pngview.c
+++ b/pngview/pngview.c
@@ -159,6 +159,29 @@ int main(int argc, char *argv[])
 
     //---------------------------------------------------------------------
 
+    IMAGE_LAYER_T imageLayer;
+
+    const char *imagePath = argv[optind];
+
+    if(strcmp(imagePath, "-") == 0) {
+        // Use stdin
+        if (loadPngFile(&(imageLayer.image), stdin) == false)
+        {
+            fprintf(stderr, "unable to load %s\n", imagePath);
+            exit(EXIT_FAILURE);
+        }
+    }
+    else {
+        // Load image from path
+        if (loadPng(&(imageLayer.image), imagePath) == false)
+        {
+            fprintf(stderr, "unable to load %s\n", imagePath);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    //---------------------------------------------------------------------
+
     if (signal(SIGINT, signalHandler) == SIG_ERR)
     {
         perror("installing SIGINT signal handler");
@@ -198,11 +221,6 @@ int main(int argc, char *argv[])
         initBackgroundLayer(&backgroundLayer, background, 0);
     }
 
-    IMAGE_LAYER_T imageLayer;
-    if (loadPng(&(imageLayer.image), argv[optind]) == false)
-    {
-        fprintf(stderr, "unable to load %s\n", argv[optind]);
-    }
     createResourceImageLayer(&imageLayer, layer);
 
     //---------------------------------------------------------------------


### PR DESCRIPTION
This instructs pngview to read the input png from `stdin` when `-` is given as the input file name.

Some changes to `loadpng.c` and `loadpng.h` were required.