### PR TITLE
Adding -c and -a flags to pngview for colour and Alpha control

### DIFF
--- a/common/image.c
+++ b/common/image.c
@@ -798,3 +798,32 @@ setImageAlphaRelative(
         }
     }
 }
+
+
+//-----------------------------------------------------------------------
+
+void
+setImageRGB (
+    IMAGE_T *image,
+    uint8_t red,
+    uint8_t green,
+    uint8_t blue)
+{
+    if (image->setPixelDirect != NULL)
+    {
+        RGBA8_T rgba;
+        int j;
+        for (j = 0 ; j < image->height ; j++)
+        {
+            int i;
+            for (i = 0 ; i < image->width ; i++)
+            {
+                getPixelRGB(image, i, j, &rgba);
+                rgba.red = red;
+                rgba.green = green;
+                rgba.blue = blue;
+                setPixelRGB(image, i, j, &rgba);
+            }
+        }
+    }
+}

--- a/common/image.c
+++ b/common/image.c
@@ -775,3 +775,26 @@ printImageTypes(
     }
 }
 
+//-----------------------------------------------------------------------
+
+void
+setImageAlphaRelative(
+    IMAGE_T *image,
+    uint8_t alpha)
+{
+    if (image->setPixelDirect != NULL)
+    {
+        RGBA8_T rgba;
+        int j;
+        for (j = 0 ; j < image->height ; j++)
+        {
+            int i;
+            for (i = 0 ; i < image->width ; i++)
+            {
+                getPixelRGB(image, i, j, &rgba);
+                rgba.alpha = (uint8_t)(rgba.alpha * (uint16_t)alpha / 255);
+                setPixelRGB(image, i, j, &rgba);
+            }
+        }
+    }
+}

--- a/common/image.h
+++ b/common/image.h
@@ -145,6 +145,11 @@ getPixelRGB(
 void
 destroyImage(
     IMAGE_T *image);
+    
+void
+setImageAlphaRelative(
+    IMAGE_T *image,
+    uint8_t alpha);
 
 //-------------------------------------------------------------------------
 

--- a/common/image.h
+++ b/common/image.h
@@ -150,6 +150,13 @@ void
 setImageAlphaRelative(
     IMAGE_T *image,
     uint8_t alpha);
+    
+void
+setImageRGB (
+    IMAGE_T *image,
+    uint8_t red,
+    uint8_t green,
+    uint8_t blue);
 
 //-------------------------------------------------------------------------
 

--- a/pngview/pngview.c
+++ b/pngview/pngview.c
@@ -85,6 +85,9 @@ void usage(void)
     fprintf(stderr, "    -y - offset (pixels from the top)\n");
     fprintf(stderr, "    -t - timeout in ms\n");
     fprintf(stderr, "    -n - non-interactive mode\n");
+    fprintf(stderr, "    -a - set relative alpha value (0-255)\n");
+    fprintf(stderr, "    -c - set image colour 24 bit RGB\n");
+    fprintf(stderr, "         e.g. 0x00FF00 is green\n");
 
     exit(EXIT_FAILURE);
 }
@@ -100,10 +103,12 @@ int main(int argc, char *argv[])
     int32_t yOffset = 0;
     uint32_t timeout = 0;
     uint8_t alphaRelative = 0;
+    uint32_t rgb = 0x000000;
     bool xOffsetSet = false;
     bool yOffsetSet = false;
     bool interactive = true;
     bool alphaRelativeSet = false;
+    bool rgbSet = false;
 
     program = basename(argv[0]);
 
@@ -111,7 +116,7 @@ int main(int argc, char *argv[])
 
     int opt = 0;
 
-    while ((opt = getopt(argc, argv, "b:d:l:x:y:t:na:")) != -1)
+    while ((opt = getopt(argc, argv, "b:d:l:x:y:t:na:c:")) != -1)
     {
         switch(opt)
         {
@@ -156,6 +161,12 @@ int main(int argc, char *argv[])
 
             alphaRelative = (uint8_t)strtol(optarg, NULL, 10);
             alphaRelativeSet = true;
+            break;
+            
+        case 'c':
+
+            rgb = strtol(optarg, NULL, 16);
+            rgbSet = true;
             break;
 
         default:
@@ -202,6 +213,16 @@ int main(int argc, char *argv[])
     if (alphaRelativeSet == true)
     {
       setImageAlphaRelative(&(imageLayer.image), alphaRelative);
+    }
+
+    //---------------------------------------------------------------------
+    
+    if (rgbSet == true)
+    {
+      uint8_t red = (rgb>>16) & 0xff;
+      uint8_t green = (rgb>>8) & 0xff;
+      uint8_t blue = rgb & 0xff;
+      setImageRGB(&(imageLayer.image), red , green, blue);
     }
 
     //---------------------------------------------------------------------

--- a/pngview/pngview.c
+++ b/pngview/pngview.c
@@ -99,9 +99,11 @@ int main(int argc, char *argv[])
     int32_t xOffset = 0;
     int32_t yOffset = 0;
     uint32_t timeout = 0;
+    uint8_t alphaRelative = 0;
     bool xOffsetSet = false;
     bool yOffsetSet = false;
     bool interactive = true;
+    bool alphaRelativeSet = false;
 
     program = basename(argv[0]);
 
@@ -109,7 +111,7 @@ int main(int argc, char *argv[])
 
     int opt = 0;
 
-    while ((opt = getopt(argc, argv, "b:d:l:x:y:t:n")) != -1)
+    while ((opt = getopt(argc, argv, "b:d:l:x:y:t:na:")) != -1)
     {
         switch(opt)
         {
@@ -150,6 +152,12 @@ int main(int argc, char *argv[])
             interactive = false;
             break;
 
+        case 'a':
+
+            alphaRelative = (uint8_t)strtol(optarg, NULL, 10);
+            alphaRelativeSet = true;
+            break;
+
         default:
 
             usage();
@@ -187,6 +195,13 @@ int main(int argc, char *argv[])
             fprintf(stderr, "unable to load %s\n", imagePath);
             exit(EXIT_FAILURE);
         }
+    }
+    
+    //---------------------------------------------------------------------
+    
+    if (alphaRelativeSet == true)
+    {
+      setImageAlphaRelative(&(imageLayer.image), alphaRelative);
     }
 
     //---------------------------------------------------------------------


### PR DESCRIPTION
Added two functions to image.c:

- **setImageAlphaRelative** allows the adjust of the alpha channel over the entire image. This gracefully manages existing alpha values so they scale proportionally. This solves issue #25 
- **setImageRGB** overrides the rgb values in the entire image, while keeping existing alpha values. 

Two flags have been added to pngview to use these functions:

- **-a** takes an alpha value between 0 and 255
- **-c** takes a 24bit hex value in the form 0xFFFFFF